### PR TITLE
Add assertions for assumptions in the code

### DIFF
--- a/src/main/java/fluke/Parser.java
+++ b/src/main/java/fluke/Parser.java
@@ -67,7 +67,9 @@ public class Parser {
         if (!typeIsFound) {
             throw new SaveFileParsingException();
         }
-        switch (typeMatcher.group()) {
+        String type = typeMatcher.group();
+        assert type.equals("[T]") || type.equals("[D]") || type.equals("[E]");
+        switch (type) {
         case "[T]":
             taskType = Fluke.Command.TODO;
             break;
@@ -89,6 +91,7 @@ public class Parser {
             throw new SaveFileParsingException();
         }
         String mark = markMatcher.group();
+        assert mark.equals("[ ]") || mark.equals("[X]");
         switch (mark) {
         case "[ ]":
             isMarked = false;

--- a/src/main/java/fluke/ui/MainWindow.java
+++ b/src/main/java/fluke/ui/MainWindow.java
@@ -41,6 +41,7 @@ public class MainWindow extends AnchorPane {
      * Creates a dialog box to greet the user.
      */
     public void greetUser() {
+        assert fluke != null;
         dialogContainer.getChildren().add(
             DialogBox.getDukeDialog(fluke.getGreeting(), dukeImage)
         );
@@ -52,6 +53,9 @@ public class MainWindow extends AnchorPane {
      */
     @FXML
     private void handleUserInput() {
+        assert userInput != null;
+        assert fluke != null;
+        assert dialogContainer != null;
         String input = userInput.getText();
         String response = fluke.getResponse(input);
         dialogContainer.getChildren().addAll(


### PR DESCRIPTION
There are no assertions in the code to make sure of key assumptions. This can cause errors which are hard to debug such as NullPointerExceptions.

Add assertions to make sure that:
1. fluke and ui elements are not null upon initialisation and upon user input.
2. save file parser regex correctly detects what is needed, e.g. the type of task.

Reasons for the above:
1. This is important because the whole application will break when fluke and ui elements are null.
2. This is important because the regex needs to work to parse the whole save file correctly.